### PR TITLE
DB dump when WP is not created for the first time

### DIFF
--- a/provisioning/roles/wordpress/handlers/main.yml
+++ b/provisioning/roles/wordpress/handlers/main.yml
@@ -4,4 +4,4 @@
     name: wpe_{{ enviro }}
     state: import
     target: "{{ wp_doc_root }}/sqldumps/wpe_{{ enviro }}.sql"
-  when: mysql_import|bool
+  when: mysql_import|bool and wp_sql.stat.exists|bool

--- a/provisioning/roles/wordpress/handlers/main.yml
+++ b/provisioning/roles/wordpress/handlers/main.yml
@@ -4,4 +4,4 @@
     name: wpe_{{ enviro }}
     state: import
     target: "{{ wp_doc_root }}/sqldumps/wpe_{{ enviro }}.sql"
-  when: mysql_import
+  when: mysql_import|bool

--- a/provisioning/roles/wordpress/tasks/main.yml
+++ b/provisioning/roles/wordpress/tasks/main.yml
@@ -10,6 +10,10 @@
     dest: "{{ wp_doc_root }}/sqldumps"
     state: directory
 
+- name: "Check if SQL file exists"
+  stat: path="{{ wp_doc_root }}/sqldumps/wpe_{{ enviro }}.sql"
+  register: wp_sql
+
 - name: "Grant {{ enviro }} WP users access to WP DBs"
   mysql_user: name="wpe_{{ enviro }}" priv="wpe_{{ enviro }}.*:ALL" host="%" password=wordpress state=present
 

--- a/provisioning/roles/wordpress/tasks/main.yml
+++ b/provisioning/roles/wordpress/tasks/main.yml
@@ -10,14 +10,6 @@
     dest: "{{ wp_doc_root }}/sqldumps"
     state: directory
 
-- name: "Back up {{ enviro }} WP database"
-  mysql_db:
-    name: wpe_{{ enviro }}
-    state: dump
-    target: "{{ wp_doc_root }}/sqldumps/wpe_{{ enviro }}.sql"
-  when: mysql_backup
-
-
 - name: "Grant {{ enviro }} WP users access to WP DBs"
   mysql_user: name="wpe_{{ enviro }}" priv="wpe_{{ enviro }}.*:ALL" host="%" password=wordpress state=present
 
@@ -152,3 +144,10 @@
     owner: "{{ web_user }}"
     group: "{{ web_user }}"
     mode: 0644
+
+- name: "Back up {{ enviro }} WP database"
+  mysql_db:
+    name: wpe_{{ enviro }}
+    state: dump
+    target: "{{ wp_doc_root }}/sqldumps/wpe_{{ enviro }}.sql"
+  when: mysql_backup|bool and ( wpnotinstalled.rc == 0 )


### PR DESCRIPTION
@zamoose Here's my adjustment idea to mitigate the issue of creating an empty SQL dump file when the WP database is created for the first time. 

Also includes a check for the existance of the SQL file on import.

I targeted this at your branch in your repo. If you merge it, I believe it'll become part of your PR to the wpengine repo.
